### PR TITLE
修复超之剑挥舞时大小未实时刷新

### DIFF
--- a/Content/Items/FSword.cs
+++ b/Content/Items/FSword.cs
@@ -2,6 +2,7 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Microsoft.Xna.Framework;
+using Terraria.DataStructures;
 
 namespace FreeStarBro.Content.Items
 {
@@ -21,16 +22,17 @@ namespace FreeStarBro.Content.Items
             Item.rare = ItemRarityID.Red;
             Item.UseSound = SoundID.Item1;
             Item.autoReuse = true;
+            // 发射剑气效果
+            Item.shoot = ProjectileID.LightBeam;
+            Item.shootSpeed = 8f;
         }
 
-        public override void UpdateInventory(Player player)
+        // 动态调整物品大小，使其在挥舞过程中实时随血量变化
+        public override void ModifyItemScale(Player player, ref float scale)
         {
-            if (player.HeldItem == Item)
-            {
-                float healthRatio = (float)player.statLife / player.statLifeMax2;
-                float scaleMultiplier = 1.0f + (1.0f - healthRatio) * 3.0f;
-                Item.scale = scaleMultiplier;
-            }
+            float healthRatio = (float)player.statLife / player.statLifeMax2;
+            float scaleMultiplier = 1.0f + (1.0f - healthRatio) * 3.0f;
+            scale *= scaleMultiplier;
         }
 
         public override void ModifyWeaponDamage(Player player, ref StatModifier damage)
@@ -40,9 +42,21 @@ namespace FreeStarBro.Content.Items
             damage *= damageMultiplier;
         }
 
+        // 挥舞时产生粒子效果
+        public override void MeleeEffects(Player player, Rectangle hitbox)
+        {
+            if (Main.rand.NextBool(3))
+            {
+                Vector2 pos = new Vector2(hitbox.X, hitbox.Y);
+                Vector2 velocity = new Vector2(Main.rand.NextFloat(-2f, 2f), Main.rand.NextFloat(-2f, 2f));
+                Dust.NewDustPerfect(pos, DustID.Enchanted_Gold, velocity, 150, default, 1.2f).noGravity = true;
+            }
+        }
+
         public override Vector2? HoldoutOffset()
         {
-            return new Vector2(-Item.width * (Item.scale - 1) / 2, -Item.height * (Item.scale - 1) / 2);
+            float adjustedScale = Main.LocalPlayer.GetAdjustedItemScale(Item);
+            return new Vector2(-Item.width * (adjustedScale - 1) / 2, -Item.height * (adjustedScale - 1) / 2);
         }
 
         public override void AddRecipes()


### PR DESCRIPTION
## 摘要
- 在 `FSword` 中实现 `ModifyItemScale`，根据玩家血量实时调整武器大小
- `HoldoutOffset` 使用 `GetAdjustedItemScale` 确保位移与实际尺寸一致
- 新增剑气，设置 `Item.shoot` 为 `LightBeam` 并调整速度
- `MeleeEffects` 生成金色粒子

## 测试
- `dotnet build` *(失败：未找到 dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_683ff711a48c8332a45e5d5994ba44c9